### PR TITLE
updated _dir, sources, and shasums; added eigenpy patch per ros-plann…

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = ros-melodic-moveit-ros-planning-interface
 	pkgdesc = ROS - Components of MoveIt that offer simpler interfaces to planning and execution.
-	pkgver = 0.10.8
-	pkgrel = 1
+	pkgver = 1.0.2
+	pkgrel = 0
 	url = https://moveit.ros.org
 	arch = any
 	license = BSD
@@ -34,8 +34,8 @@ pkgbase = ros-melodic-moveit-ros-planning-interface
 	depends = ros-melodic-moveit-ros-manipulation
 	depends = ros-melodic-rosconsole
 	depends = python
-	source = ros-melodic-moveit-ros-planning-interface-0.10.8-0.tar.gz::https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_planning_interface/0.10.8-0.tar.gz
-	sha256sums = 748d5e2ca554190c84b0e43be8aa44c9b76c5e2a77e9d87eac5619147604a174
+	source = ros-melodic-moveit-ros-planning-interface-1.0.2.tar.gz::https://github.com/ros-planning/moveit/archive/1.0.2.tar.gz
+	sha256sums = b8194308c57dbe34bbb729cfccb30d1113af3a54a90a2cfb49482142d1044ea4
 
 pkgname = ros-melodic-moveit-ros-planning-interface
 

--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = ros-melodic-moveit-ros-planning-interface
 	pkgdesc = ROS - Components of MoveIt that offer simpler interfaces to planning and execution.
 	pkgver = 1.0.2
-	pkgrel = 0
+	pkgrel = 1
 	url = https://moveit.ros.org
 	arch = any
 	license = BSD
@@ -34,8 +34,11 @@ pkgbase = ros-melodic-moveit-ros-planning-interface
 	depends = ros-melodic-moveit-ros-manipulation
 	depends = ros-melodic-rosconsole
 	depends = python
+	depends = eigenpy
 	source = ros-melodic-moveit-ros-planning-interface-1.0.2.tar.gz::https://github.com/ros-planning/moveit/archive/1.0.2.tar.gz
+	source = eigenpy.patch
 	sha256sums = b8194308c57dbe34bbb729cfccb30d1113af3a54a90a2cfb49482142d1044ea4
+	sha256sums = 797e2415ec9c66b2f7137bb6c0037e4f0ef5520baba7eff3af3eb04119e42b40
 
 pkgname = ros-melodic-moveit-ros-planning-interface
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -3,8 +3,7 @@ pkgdesc="ROS - Components of MoveIt that offer simpler interfaces to planning an
 url='https://moveit.ros.org'
 
 pkgname='ros-melodic-moveit-ros-planning-interface'
-pkgver='0.10.8'
-_pkgver_patch=0
+pkgver='1.0.2'
 arch=('any')
 pkgrel=1
 license=('BSD')
@@ -39,7 +38,8 @@ ros_depends=(ros-melodic-tf-conversions
   ros-melodic-moveit-ros-manipulation
   ros-melodic-rosconsole)
 depends=(${ros_depends[@]}
-  python)
+  python
+  eigenpy)
 
 # Git version (e.g. for debugging)
 # _tag=release/melodic/moveit_ros_planning_interface/${pkgver}-${_pkgver_patch}
@@ -48,17 +48,23 @@ depends=(${ros_depends[@]}
 # sha256sums=('6cbf0b256af768dcd336ff60b142a2f1d363c79879c30bbe5bc0952c0375b2e8')
 
 # Tarball version (faster download)
-_dir="moveit-release-release-melodic-moveit_ros_planning_interface-${pkgver}-${_pkgver_patch}"
-source=("${pkgname}-${pkgver}-${_pkgver_patch}.tar.gz"::"https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_planning_interface/${pkgver}-${_pkgver_patch}.tar.gz")
-sha256sums=('748d5e2ca554190c84b0e43be8aa44c9b76c5e2a77e9d87eac5619147604a174')
+_dir="moveit-${pkgver}/moveit_ros/planning_interface"
+source=("${pkgname}-${pkgver}.tar.gz"::"https://github.com/ros-planning/moveit/archive/${pkgver}.tar.gz"
+  "eigenpy.patch")
+sha256sums=('b8194308c57dbe34bbb729cfccb30d1113af3a54a90a2cfb49482142d1044ea4'
+  '797e2415ec9c66b2f7137bb6c0037e4f0ef5520baba7eff3af3eb04119e42b40')
 
 prepare() {
+  cd ${srcdir}/${_dir}
+  patch -uN CMakeLists.txt ${srcdir}/eigenpy.patch || return 1
+
   cd ${srcdir}
   find . \( -iname *.cpp -o -iname *.h \) \
 	  -exec sed -r -i "s/[^_]logError/CONSOLE_BRIDGE_logError/" {} \; \
 	  -exec sed -r -i "s/[^_]logWarn/CONSOLE_BRIDGE_logWarn/" {} \; \
 	  -exec sed -r -i "s/[^_]logDebug/CONSOLE_BRIDGE_logDebug/" {} \; \
 	  -exec sed -r -i "s/[^_]logInform/CONSOLE_BRIDGE_logInform/" {} \;
+
 }
 
 build() {

--- a/eigenpy.patch
+++ b/eigenpy.patch
@@ -1,0 +1,29 @@
+diff --git a/moveit_ros/planning_interface/CMakeLists.txt b/moveit_ros/planning_interface/CMakeLists.txt
+index d1b5594b1..a5e130843 100644
+--- a/moveit_ros/planning_interface/CMakeLists.txt
++++ b/moveit_ros/planning_interface/CMakeLists.txt
+@@ -19,13 +19,15 @@ find_package(catkin REQUIRED COMPONENTS
+   tf2_eigen
+   tf2_geometry_msgs
+   tf2_ros
+-  eigenpy
+   roscpp
+   actionlib
+   rospy
+   rosconsole
+ )
+ 
++find_package(PkgConfig REQUIRED)
++pkg_check_modules(eigenpy eigenpy REQUIRED)
++
+ find_package(PythonInterp REQUIRED)
+ find_package(PythonLibs "${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}" REQUIRED)
+ 
+@@ -77,6 +79,7 @@ catkin_package(
+ 
+ include_directories(${THIS_PACKAGE_INCLUDE_DIRS}
+                     ${Boost_INCLUDE_DIRS}
++                    ${eigenpy_INCLUDE_DIRS}
+                     ${catkin_INCLUDE_DIRS})
+ 
+ include_directories(SYSTEM


### PR DESCRIPTION
For most packages, I'm just pushing the upstream url fixes to master branch. On this one, I ran into a snag with `eigenpy`. I added to the depends and had it installed, but got this error:
```
-- Could not find the required component 'eigenpy'. The following CMake error indicates that you either need to install the package with the same name or change your environment so that it can be found.
CMake Error at /opt/ros/melodic/share/catkin/cmake/catkinConfig.cmake:83 (find_package):
  Could not find a package configuration file provided by "eigenpy" with any
  of the following names:

    eigenpyConfig.cmake
    eigenpy-config.cmake

  Add the installation prefix of "eigenpy" to CMAKE_PREFIX_PATH or set
  "eigenpy_DIR" to a directory containing one of the above files.  If
  "eigenpy" provides a separate development package or SDK, be sure it has
  been installed.
Call Stack (most recent call first):
  CMakeLists.txt:10 (find_package)


-- Configuring incomplete, errors occurred!
```

I posted on eigenpy, but then [found a PR](https://github.com/ros-planning/moveit/pull/1550) on moveit which worked for me. Options:

- wait: it seems like eigenpy and moveit are in dialog about what to do
- rely on ros-gbp: leave this package on the ros-gbp version vs. upstream; no idea if this will break other packages that depend on it (which are now successfully on upstream)
- use the added patch, which at least let's it build (my vote)